### PR TITLE
Add support for std::enable_shared_from_this

### DIFF
--- a/Source/KCL/KCL_RTTI.h
+++ b/Source/KCL/KCL_RTTI.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <type_traits>
 
 #include "KCL_Platform.h"
@@ -177,6 +178,12 @@ struct TypeData
 template<typename... BaseTypes>
 struct BaseTypeData
 {
+};
+
+template <typename Type>
+struct BaseTypeData<std::enable_shared_from_this<Type>> {
+  template <typename Derived>
+  void FillBaseTypeData(std::ptrdiff_t, typeId_t&) {}
 };
 
 template<typename FirstBase, typename SecondBase, typename... Next>


### PR DESCRIPTION
Really like the RTTI system!

This seems to enable support for std::enable_shared_from_this

Example usage:

class Shared : public std::enable_shared_from_this<Shared> {
 public:
  KCL_RTTI_IMPL_BASE();

  virtual ~Shared() {}
};
KCL_RTTI_REGISTER(Shared, std::enable_shared_from_this<Shared>)